### PR TITLE
Updated Files

### DIFF
--- a/CommandKit.java
+++ b/CommandKit.java
@@ -1,0 +1,178 @@
+package de.Brogamer5000.tagGame;
+
+import java.io.File;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import de.Brogamer5000.tagGame.util.tagStorage;
+
+public class CommandKit implements CommandExecutor{
+
+	public tagStorage taggedPlayer;
+	public String pluginPraefix = "";
+	
+	public CommandKit(String pluginFolder, String pluginPraefix) {
+		
+		String HistoryTagFile = pluginFolder + File.separator + "taggedHistory.txt";
+		String TabooListFile = pluginFolder + File.separator + "tabooList.txt";
+		
+		this.taggedPlayer = new tagStorage(new File(HistoryTagFile), new File(TabooListFile));
+		this.taggedPlayer.load();
+		
+		this.pluginPraefix = pluginPraefix;
+		
+	}
+	
+	
+	
+	@Override
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+
+		Player player = (Player) sender;
+		
+		String action = "help";
+		String arg = "";
+		
+		if(args.length > 0) { 
+			
+			if(!args[0].equalsIgnoreCase("")) {
+				action = args[0];
+			}
+			
+			if(args.length > 1) {
+				if(!args[1].equalsIgnoreCase("")) {
+					arg = args[1];
+				}
+			}
+		}
+
+		
+/////////////////////////////////////////
+//......help Befehl....................//
+/////////////////////////////////////////		
+		if(action.equalsIgnoreCase("help") || action.equalsIgnoreCase("?")) {
+			
+			player.sendMessage("-------------- " + this.pluginPraefix + "--------------");
+			player.sendMessage(				"§6/taggame get §fNennt den aktuell getaggten Spieler");
+			player.sendMessage(				"§6/taggame get taboo §fListet alle Spieler aus der Tabu-Liste auf");
+			player.sendMessage(				"§6/taggame help §fZeigt diese Liste");
+			
+			if(player.hasPermission("§6taggame.reset")) {
+				player.sendMessage(			"§6/taggame reset §fSetzt das Spiel zurück. Die Tabu Liste bleibt erhalten!");
+			}
+			
+			if(player.hasPermission("§6taggame.forceset")) {
+				player.sendMessage(			"§6/taggame forceset <player> §fÄndert den aktuell getaggten Spieler zum angegebenen Spieler");
+			}
+			
+			player.sendMessage("-------------- " + this.pluginPraefix + "--------------");
+			
+			return true;
+		}
+		
+		
+/////////////////////////////////////////
+//......get Befehl.....................//
+/////////////////////////////////////////
+		
+		
+		else if(action.equalsIgnoreCase("get")) {
+			
+			if(arg.equalsIgnoreCase("taboo")) { 
+				player.sendMessage(this.pluginPraefix + "Tabu sind folgende Spieler: " + this.taggedPlayer.getTabooList());
+			}
+			else {
+				player.sendMessage(this.pluginPraefix + "Aktuell getaggt ist: " + this.taggedPlayer.get());	
+			}
+			
+			return true;
+		
+		}
+		
+		
+		
+/////////////////////////////////////////
+//......reset Befehl...................//
+/////////////////////////////////////////
+		
+		else if(action.equalsIgnoreCase("reset")) {
+			
+			if(player.hasPermission("taggame.reset")) {
+			
+				String playername = player.getName();
+
+				taggedPlayer.resetAll(playername);
+				player.sendMessage(this.pluginPraefix + "Das Tag Spiel wurde zurückgesetzt. Du bist wurdest automatisch getaggt!");
+				
+				return true;
+				
+			}
+			else {
+				
+				return false;
+			
+			}
+			
+		}
+
+		
+		
+/////////////////////////////////////////
+//......forceset Befehl................//
+/////////////////////////////////////////
+		
+		else if(action.equalsIgnoreCase("forceset")) {
+			//only allow access, if user has the permission
+			if(player.hasPermission("taggame.forceset")) {
+			
+				//return error, when no arg is given
+				if(arg.equalsIgnoreCase("") == true) {
+					
+					return false;
+				
+				}
+				else {
+				
+					taggedPlayer.forceSet(arg);
+					player.sendMessage(this.pluginPraefix + "Du hast " + arg + " zwangsweise als Tag markiert!");
+					
+					return true;	
+			
+				}
+				
+			}
+			
+		}
+		
+		
+/////////////////////////////////////////
+//......taboo Befehl...................//
+/////////////////////////////////////////
+		
+		else if(action.equalsIgnoreCase("taboo")) {
+			
+			String playername = player.getName();
+
+			boolean wasSetToTaboo = this.taggedPlayer.toggleTaboo(playername);
+
+			if(wasSetToTaboo) {
+				player.sendMessage(this.pluginPraefix + "Du wurdest zur Tabu-Liste hinzugefügt!");
+			}
+			else {
+				player.sendMessage(this.pluginPraefix + "Du wurdest von der Tabu-Liste entfernt!");	
+			}
+			
+			return true;
+			
+		}
+		
+					
+		//false, wenn syntax verbesserung angezeigt werden soll
+		return false;
+	}
+
+}
+

--- a/CustomEventHandler.java
+++ b/CustomEventHandler.java
@@ -1,0 +1,110 @@
+package de.Brogamer5000.tagGame;
+
+import java.util.List;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import com.sk89q.worldguard.bukkit.protection.events.DisallowedPVPEvent;
+
+import de.Brogamer5000.tagGame.util.tagStorage;
+
+
+public class CustomEventHandler implements Listener{
+	
+	tagGame plugin;
+	
+	
+	
+	public CustomEventHandler (tagGame plugin) {
+		this.plugin = plugin;
+		plugin.getServer().getPluginManager().registerEvents(this, plugin);
+	}
+	
+	
+	
+	
+    @EventHandler(priority = EventPriority.HIGHEST)
+	public void onHit(DisallowedPVPEvent e) {
+    	
+
+    	//get target and attacker from DisallowedPVPEvent
+    	Player target = (Player) e.getDefender();
+    	Player attacker = (Player) e.getAttacker();
+    	
+    	
+        if (target instanceof Player && attacker instanceof Player) {
+            
+            
+            //get current infos and methods of the tagged Player
+            tagStorage taggedPlayer = tagGame.commandExecutor.taggedPlayer;
+            List<String> tagHistory = taggedPlayer.historyList;
+            
+            String currentTag = 	(tagHistory.size() >= 1) ? tagHistory.get(tagHistory.size()-1) : "unset";
+            String lastTag = 		(tagHistory.size() >= 2) ? tagHistory.get(tagHistory.size()-2) : "unset";
+            
+            
+            
+            //test, if the attacker is the tagged player
+            if(currentTag.equalsIgnoreCase(attacker.getName())) {
+            	
+            	
+            	//test, if the target is currently marked as afk (not used)
+            	boolean targetIsAfk = false;
+            	
+            	/*
+            	 
+                //try to get Infos from the afk plugin
+                try {
+                	Plugin zw2afk = plugin.getServer().getPluginManager().getPlugin("Zw2Afk");
+                	ArrayList<UUID> afkList = zw2afk.AFK_LIST; 
+                	if(afkList.contains(target.getUniqueId())) {
+                		targetIsAfk = true;
+                	}
+                }
+                catch(Exception ex) {
+                	ex.printStackTrace();
+                }
+                
+                */
+            	
+            	//test, if target is listed in the taboo list
+            	if(taggedPlayer.isTaboo(target.getName())) {
+            		
+            		attacker.sendMessage(tagGame.prefix + "§4" + target.getName() + " steht auf der Tabu Liste!");
+            	
+            	}
+            	
+            	//else: test, if the target was the one, that gave the tag to the attacker
+            	else if(lastTag.equalsIgnoreCase(target.getName())) {
+            		
+            		attacker.sendMessage(tagGame.prefix + "§4Du kannst " + target.getName() + " nicht zurück taggen!");
+            	
+            	}
+            	
+            	//else: test, if target is afk at the moment
+            	else if(targetIsAfk) {
+            	
+            		attacker.sendMessage(tagGame.prefix + "§4" + target.getName() + " ist Afk!");
+            	
+            	}
+            	
+            	//else: attacker is succesfully tagging the target!
+            	else {
+            		
+            		//send Messages to both, the attacker and the target
+            		attacker.sendMessage(tagGame.prefix + "Du hast " + target.getName() + " erfolgreich getaggt!");
+            		target.sendMessage(tagGame.prefix + "Du wurdest von " + attacker.getName() + " getaggt!");
+                	
+            		//call the set function in the instance of taggedPlayer
+            		taggedPlayer.set(target.getName());            		
+                    
+            	}
+            }   
+        }        
+    }
+}

--- a/TabComplete.java
+++ b/TabComplete.java
@@ -1,0 +1,78 @@
+package de.Brogamer5000.tagGame;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+
+public class TabComplete implements TabCompleter{
+
+	@Override
+	public List<String> onTabComplete(CommandSender arg0, Command arg1, String arg2, String[] arg3) {
+		
+		//get a list of all given params
+		List<String> params = new ArrayList<String>();
+		for(int i = 0; i < arg3.length; i++) {
+			params.add(arg3[i]);
+		}
+		
+		//create an empty List
+		List<String> hints = new ArrayList<String>();
+
+		
+		
+		
+		//If user is writing the first param of the command
+		if(params.size() == 1) {
+			
+			//add the basic suggestion
+			hints.add("get");
+			hints.add("taboo");
+			hints.add("help");
+			
+			//add the following two suggestions only, if player has the permissions
+			if(arg0.hasPermission("taggame.reset")) {
+				hints.add("reset");
+			}
+			
+			if(arg0.hasPermission("taggame.forceset")) {
+				hints.add("forceset");
+			}
+			
+		}
+		
+		
+		
+		
+		//If user is writing the second param of the command
+		else if(params.size() == 2) {
+			
+			//when first param was "get"
+			if(params.get(0).equalsIgnoreCase("get")) {
+				
+				hints.add("taboo");
+				hints.add("current"); //only used for completeness. Not used directly, but shows the player that there is more than one option
+			
+			}
+			
+			//if first param was "forceset"
+			else if(params.get(0).equalsIgnoreCase("forceset")) {
+		
+				//show no hints, but instead the playerlist by returning null
+				return null;
+			
+			}
+			
+		}
+		
+		
+		
+		
+		//return the list of hints
+        return hints;
+        
+	}
+	
+}

--- a/tagGame.java
+++ b/tagGame.java
@@ -1,0 +1,72 @@
+package de.Brogamer5000.tagGame;
+
+import java.io.File;
+import java.util.logging.Logger;
+
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class tagGame extends JavaPlugin implements Listener{	
+	
+	public static CommandKit commandExecutor;
+	public static tagGame instance;
+	public static Logger logger;
+	public static String prefix;
+	
+	//im Plugin genutzte Berechtigungen:
+	// taggame.reset 
+	//		-> Berechtigung zum Resetten des Verlaufs
+	// taggame.forceset
+	//		-> Berechtigung zum zwangsweise ändern der getaggten Person 
+	//				- der alte tag wird überschrieben (!)
+	//				- man muss nicht selbst getaggt sein
+	//				- es kann selbst eine person aus der Tabu liste getaggt werden
+	
+	
+	@Override
+	public void onEnable() {
+
+		//create information for the logger
+		instance = this;
+		prefix = "§5[tagGame] §f";
+		logger = getLogger();
+		
+		//create folder for the stored Information
+		String pluginFolder = this.getDataFolder().getAbsolutePath();
+		new File(pluginFolder).mkdir();
+		
+		
+		//save instance of the command-collection class
+		commandExecutor =  new CommandKit(pluginFolder, prefix);
+		
+		//add the 'taggame' command and set its executor and tabCompleter
+		this.getCommand("taggame").setExecutor(commandExecutor);
+		this.getCommand("taggame").setTabCompleter(new TabComplete());
+		
+		
+		//create the eventhandler
+		new CustomEventHandler(this);
+		
+		
+		this.getLogger().info("Taggame-Plugin successfully enabled");
+		
+	}
+	
+	
+	
+	
+	
+	@Override
+	public void onDisable() {
+		
+		//save everything
+		commandExecutor.taggedPlayer.save();
+		
+		this.getLogger().info("Taggame-Plugin successfully disabled");
+	
+	}
+
+	
+}
+
+

--- a/tagStorage.java
+++ b/tagStorage.java
@@ -1,0 +1,244 @@
+package de.Brogamer5000.tagGame.util;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class tagStorage {
+
+	private File historyFile;
+	private File tabooFile;
+	public List<String> tabooList = new ArrayList<String> ();
+	public List<String> historyList = new ArrayList<String> ();
+	
+///////////////////////////////////////////////////////////////////////
+////....................Konstruktor Funktion.......................////
+///////////////////////////////////////////////////////////////////////
+	
+	
+	public tagStorage(File history, File taboo) {
+		
+		this.historyFile = history;
+		this.tabooFile = taboo;
+		
+	
+		//test if file exists
+		if(this.historyFile.exists() == false || this.tabooFile.exists() == false) {
+			//create the File
+			try {
+				this.historyFile.createNewFile();
+				this.tabooFile.createNewFile();
+			} catch (IOException e) {
+				e.printStackTrace();
+			}
+			
+		}
+		
+	}
+	
+	
+///////////////////////////////////////////////////////////////////////
+////....................Save und Load Funktionen...................////
+///////////////////////////////////////////////////////////////////////
+	
+	public void load() {
+		
+		try {
+			//load current tagged player
+			DataInputStream input = new DataInputStream(new FileInputStream(this.historyFile));
+			BufferedReader reader = new BufferedReader(new InputStreamReader(input));
+			
+			String line;
+			
+			while((line = reader.readLine()) != null) {
+					this.historyList.add(line);
+			}
+			
+			reader.close();
+			input.close();
+			
+			
+			//if no player was ever tagged, add a dummy player
+			if(this.historyList.size() == 0) {
+				this.historyList.add("dummyPlayer - Please use /taggame reset");
+			}
+		
+			
+			//load taboo Listed Players
+			DataInputStream tabooInput = new DataInputStream(new FileInputStream(this.tabooFile));
+			BufferedReader tabooReader = new BufferedReader(new InputStreamReader(tabooInput));
+			
+			line = null;
+			
+			while((line = tabooReader.readLine()) != null) {
+					this.tabooList.add(line);
+			}
+			
+			tabooReader.close();
+			tabooInput.close();
+		
+		
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		
+	}
+	
+
+	public void save() {
+		
+		try {
+			//save the history to the history-file
+			FileWriter stream = new FileWriter(this.historyFile, false);
+			BufferedWriter out = new BufferedWriter(stream);
+			
+			for(int i = 0; i < this.historyList.size(); i++) {
+				if(i > 0) {
+					out.write("\n");
+				}
+				out.write(this.historyList.get(i).replace("\\", ""));
+			}
+						
+			out.close();
+			stream.close();
+
+			
+			//save the taboo list to the taboo file
+			FileWriter streamTaboo = new FileWriter(this.tabooFile, false);
+			BufferedWriter outTaboo = new BufferedWriter(streamTaboo);
+			
+			for(int i = 0; i < this.tabooList.size(); i++) {
+				if(i > 0) {
+					out.write("\n");
+				}
+				outTaboo.write(this.tabooList.get(i).replace("\\", ""));	
+			}
+			
+			outTaboo.close();
+			streamTaboo.close();
+			
+			
+		}
+		catch (IOException e) {
+			e.printStackTrace();
+		}
+	
+	}
+	
+
+///////////////////////////////////////////////////////////////////////
+////....................Sonstiges..................................////
+///////////////////////////////////////////////////////////////////////	
+	
+	public boolean isequalto(String value) {
+		
+		String savedName = this.historyList.get(this.historyList.size()-1).trim();
+		String givenName = value.trim();
+		
+		if(savedName.equalsIgnoreCase(givenName)) 	return true;
+		else 										return false;
+		
+	}
+	
+	
+///////////////////////////////////////////////////////////////////////
+////....................Get und Set Funktionen.....................////
+///////////////////////////////////////////////////////////////////////
+
+	
+	public void set(String playername) {
+	
+		this.historyList.add(playername);
+		this.save();
+	
+	}
+		
+	public String get() {
+		
+		String value = (this.historyList.size() > 0) ? this.historyList.get(this.historyList.size()-1) : "unset";
+		return value;
+	
+	}
+	
+	
+	
+///////////////////////////////////////////////////////////////////////
+////....................Taboo Liste................................////
+///////////////////////////////////////////////////////////////////////
+
+	
+	public boolean isTaboo(String value) {
+		
+		if(this.tabooList.contains(value)) return true;
+		else							   return false;
+		
+	}
+	
+	public boolean toggleTaboo(String value) {
+		
+		if(this.tabooList.contains(value)) 	this.tabooList.remove(value);
+		else 								this.tabooList.add(value);
+		
+		return isTaboo(value);
+		
+	}
+	
+	
+	public String getTabooList() {
+		
+		
+		
+		String tabooString = "";
+		for(int i = 0; i < this.tabooList.size(); i++) {
+			if(i > 0) {
+				tabooString += "\n";
+			}
+			tabooString += this.tabooList.get(i);
+		}
+		return tabooString;
+	
+	}
+	
+	
+	
+///////////////////////////////////////////////////////////////////////
+////....................Admin-only Funktionen......................////
+///////////////////////////////////////////////////////////////////////
+
+	
+	public void resetAll(String newTaggedPlayer) {
+		
+		//declare new tagged player: the user, that runs this
+		this.historyList.clear();
+		this.historyList.add(newTaggedPlayer);
+		
+	}
+
+	
+	
+	public boolean forceSet(String newTaggedPlayer) {
+		
+	    if(this.historyList.size() > 0) {
+	    	
+		    int i = this.historyList.size()-1;
+		    this.historyList.set(i, newTaggedPlayer);
+		    
+		    return true;
+	    
+	    }
+	    else {
+	    	
+	    	return false;
+	    	
+	    }
+	}
+	
+}


### PR DESCRIPTION
- Einzelne Verbesserungen am Code
- Es wird nun das Worldguard "DisallowPvpEvent" genutzt, anstatt des EntityHitByEntity-Events
- Anstatt die Tag-Liste und die Tabu-Liste bei jeder Veränderung direkt abzuspeichern, wird dies nun nur einmal beim Deaktivieren gemacht.
- Ist beim Laden des Plugins die Tag-Liste leer, wird ein Platzhalter eingefügt mit dem namen "dummyPlayer - please use /taggame reset"

Offene Probleme:
- Wenn ein Spieler einen anderen tagged, bekommt er trotzdem die Nachricht "Hey! Sorry, but you can´t pvp here!"
- Code-bereinigung steht noch immer offen, weil ich sehr, sehr faul bin :P