### PR TITLE
Updated Files

### DIFF
--- a/src/de/Brogamer5000/tagGame/CommandKit.java
+++ b/src/de/Brogamer5000/tagGame/CommandKit.java
@@ -54,18 +54,22 @@ public class CommandKit implements CommandExecutor{
 //......help Befehl....................//
 /////////////////////////////////////////		
 		if(action.equalsIgnoreCase("help") || action.equalsIgnoreCase("?")) {
+			
 			player.sendMessage("-------------- " + this.pluginPraefix + "--------------");
 			player.sendMessage(				"§6/taggame get §fNennt den aktuell getaggten Spieler");
 			player.sendMessage(				"§6/taggame get taboo §fListet alle Spieler aus der Tabu-Liste auf");
-			player.sendMessage(				"§6/taggame set <player> §fÜbergibt den Tag an den angegebenen Spieler");
 			player.sendMessage(				"§6/taggame help §fZeigt diese Liste");
+			
 			if(player.hasPermission("§6taggame.reset")) {
 				player.sendMessage(			"§6/taggame reset §fSetzt das Spiel zurück. Die Tabu Liste bleibt erhalten!");
 			}
+			
 			if(player.hasPermission("§6taggame.forceset")) {
 				player.sendMessage(			"§6/taggame forceset <player> §fÄndert den aktuell getaggten Spieler zum angegebenen Spieler");
 			}
+			
 			player.sendMessage("-------------- " + this.pluginPraefix + "--------------");
+			
 			return true;
 		}
 		
@@ -76,59 +80,18 @@ public class CommandKit implements CommandExecutor{
 		
 		
 		else if(action.equalsIgnoreCase("get")) {
+			
 			if(arg.equalsIgnoreCase("taboo")) { 
 				player.sendMessage(this.pluginPraefix + "Tabu sind folgende Spieler: " + this.taggedPlayer.getTabooList());
 			}
 			else {
 				player.sendMessage(this.pluginPraefix + "Aktuell getaggt ist: " + this.taggedPlayer.get());	
 			}
+			
 			return true;
+		
 		}
 		
-		
-		
-/* Unused development tool!!!		
-/////////////////////////////////////////
-//......set Befehl.....................//
-/////////////////////////////////////////
-		else if(action.equalsIgnoreCase("set")) {
-			String playername = player.getName();
-			
-			
-			
-			//deny access if user is not currently tagged
-			if(!this.taggedPlayer.isequalto(playername)) {
-				player.sendMessage(this.pluginPraefix + "Nur die getaggte Person kann jemand anderen taggen!");
-				return true;
-			}
-			
-			else {					
-				
-				//deny, if arg1 is no username
-				if(arg.equalsIgnoreCase("")) {
-					return false;
-				}
-				
-				//deny, if player tries to tag itself
-				if(arg.equalsIgnoreCase(playername)) {
-					player.sendMessage(this.pluginPraefix + "Du kannst dich nicht selbst taggen!");
-					return true;
-				}
-				
-				//deny if player tries to tag a player on the taboo list
-				if(this.taggedPlayer.isTaboo(arg)) {
-					player.sendMessage(this.pluginPraefix + arg + " steht auf der Tabu-Liste!");
-					return true;
-				}
-				
-				
-				this.taggedPlayer.set(arg);
-				player.sendMessage(this.pluginPraefix + "Du hast " + arg + " getaggt!");
-				return true;
-			}
-			
-		}
-*/		
 		
 		
 /////////////////////////////////////////
@@ -136,16 +99,23 @@ public class CommandKit implements CommandExecutor{
 /////////////////////////////////////////
 		
 		else if(action.equalsIgnoreCase("reset")) {
+			
 			if(player.hasPermission("taggame.reset")) {
+			
 				String playername = player.getName();
 
 				taggedPlayer.resetAll(playername);
-				player.sendMessage(this.pluginPraefix + "Das Tag Spiel wurde zurückgesetzt. Du bist nun getaggt!");
+				player.sendMessage(this.pluginPraefix + "Das Tag Spiel wurde zurückgesetzt. Du bist wurdest automatisch getaggt!");
+				
 				return true;
+				
 			}
 			else {
+				
 				return false;
+			
 			}
+			
 		}
 
 		
@@ -155,11 +125,26 @@ public class CommandKit implements CommandExecutor{
 /////////////////////////////////////////
 		
 		else if(action.equalsIgnoreCase("forceset")) {
+			//only allow access, if user has the permission
 			if(player.hasPermission("taggame.forceset")) {
-				taggedPlayer.forceSet(arg);
-				player.sendMessage(this.pluginPraefix + "Du hast " + arg + " zwangsweise als Tag markiert!");
-				return true;
+			
+				//return error, when no arg is given
+				if(arg.equalsIgnoreCase("") == true) {
+					
+					return false;
+				
+				}
+				else {
+				
+					taggedPlayer.forceSet(arg);
+					player.sendMessage(this.pluginPraefix + "Du hast " + arg + " zwangsweise als Tag markiert!");
+					
+					return true;	
+			
+				}
+				
 			}
+			
 		}
 		
 		
@@ -168,6 +153,7 @@ public class CommandKit implements CommandExecutor{
 /////////////////////////////////////////
 		
 		else if(action.equalsIgnoreCase("taboo")) {
+			
 			String playername = player.getName();
 
 			boolean wasSetToTaboo = this.taggedPlayer.toggleTaboo(playername);

--- a/src/de/Brogamer5000/tagGame/CustomEventHandler.java
+++ b/src/de/Brogamer5000/tagGame/CustomEventHandler.java
@@ -6,7 +6,10 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+import com.sk89q.worldguard.bukkit.protection.events.DisallowedPVPEvent;
 
 import de.Brogamer5000.tagGame.util.tagStorage;
 
@@ -15,40 +18,49 @@ public class CustomEventHandler implements Listener{
 	
 	tagGame plugin;
 	
+	
+	
 	public CustomEventHandler (tagGame plugin) {
 		this.plugin = plugin;
 		plugin.getServer().getPluginManager().registerEvents(this, plugin);
 	}
 	
-    @EventHandler(priority = EventPriority.MONITOR)
-	public void onHit(EntityDamageByEntityEvent e) {
-    	System.out.println("entity hit");
-        if (e.getEntity() instanceof Player && e.getDamager() instanceof Player) {
-            Player target = (Player) e.getEntity();
-            Player attacker = (Player) e.getDamager();
+	
+	
+	
+    @EventHandler(priority = EventPriority.HIGHEST)
+	public void onHit(DisallowedPVPEvent e) {
+    	
+
+    	//get target and attacker from DisallowedPVPEvent
+    	Player target = (Player) e.getDefender();
+    	Player attacker = (Player) e.getAttacker();
+    	
+
+    	System.out.println("test");
+
+    	
+        if (target instanceof Player && attacker instanceof Player) {
             
             
-            //get Infos and methods of the tagged Player
-            tagStorage taggedPlayer = this.plugin.commandExecutor.taggedPlayer;
-            
-            
+            //get current infos and methods of the tagged Player
+            tagStorage taggedPlayer = tagGame.commandExecutor.taggedPlayer;
             List<String> tagHistory = taggedPlayer.historyList;
-            String currentTag = "unset";
-            String lastTag = "unset";
-            if(tagHistory.size() > 0) {
-            	currentTag = tagHistory.get(tagHistory.size()-1);
-            }
-            if(tagHistory.size() > 1) {
-            	lastTag = tagHistory.get(tagHistory.size()-2);	
-            }
             
+            String currentTag = 	(tagHistory.size() >= 1) ? tagHistory.get(tagHistory.size()-1) : "unset";
+            String lastTag = 		(tagHistory.size() >= 2) ? tagHistory.get(tagHistory.size()-2) : "unset";
+            
+            
+            
+            //test, if the attacker is the tagged player
             if(currentTag.equalsIgnoreCase(attacker.getName())) {
             	
+            	
+            	//test, if the target is currently marked as afk (not used)
             	boolean targetIsAfk = false;
             	
-            	
             	/*
-            	 * 
+            	 
                 //try to get Infos from the afk plugin
                 try {
                 	Plugin zw2afk = plugin.getServer().getPluginManager().getPlugin("Zw2Afk");
@@ -63,29 +75,39 @@ public class CustomEventHandler implements Listener{
                 
                 */
             	
-            	
-            	
-            	
-                
-                
+            	//test, if target is listed in the taboo list
             	if(taggedPlayer.isTaboo(target.getName())) {
-            		attacker.sendMessage(plugin.pluginPraefix + "§4" + target.getName() + " steht auf der Tabu Liste!");
+            		
+            		attacker.sendMessage(tagGame.prefix + "§4" + target.getName() + " steht auf der Tabu Liste!");
+            	
             	}
-            	else if(targetIsAfk) {
-            		attacker.sendMessage(plugin.pluginPraefix + "§4" + target.getName() + " ist Afk!");
-            	}
+            	
+            	//else: test, if the target was the one, that gave the tag to the attacker
             	else if(lastTag.equalsIgnoreCase(target.getName())) {
-            		attacker.sendMessage(plugin.pluginPraefix + "§4Du kannst " + target.getName() + " nicht zurück taggen!");
+            		
+            		attacker.sendMessage(tagGame.prefix + "§4Du kannst " + target.getName() + " nicht zurück taggen!");
+            	
             	}
+            	
+            	//else: test, if target is afk at the moment
+            	else if(targetIsAfk) {
+            	
+            		attacker.sendMessage(tagGame.prefix + "§4" + target.getName() + " ist Afk!");
+            	
+            	}
+            	
+            	//else: attacker is succesfully tagging the target!
             	else {
-            		attacker.sendMessage(plugin.pluginPraefix + "Du hast " + target.getName() + " erfolgreich getaggt!");
-            		target.sendMessage(plugin.pluginPraefix + "Du wurdest von " + attacker.getName() + " getaggt!");
-                	taggedPlayer.set(target.getName());            		
+            		
+            		//send Messages to both, the attacker and the target
+            		attacker.sendMessage(tagGame.prefix + "Du hast " + target.getName() + " erfolgreich getaggt!");
+            		target.sendMessage(tagGame.prefix + "Du wurdest von " + attacker.getName() + " getaggt!");
+                	
+            		//call the set function in the instance of taggedPlayer
+            		taggedPlayer.set(target.getName());            		
+                    
             	}
-            }
-            
-            
-        }
+            }   
+        }        
     }
-	
 }

--- a/src/de/Brogamer5000/tagGame/TabComplete.java
+++ b/src/de/Brogamer5000/tagGame/TabComplete.java
@@ -18,39 +18,59 @@ public class TabComplete implements TabCompleter{
 			params.add(arg3[i]);
 		}
 		
-		
+		//create an empty List
 		List<String> hints = new ArrayList<String>();
 
 		
 		
 		
-		//Vorschläge für den ersten Eintrag
+		//If user is writing the first param of the command
 		if(params.size() == 1) {
+			
+			//add the basic suggestion
 			hints.add("get");
 			hints.add("taboo");
 			hints.add("help");
+			
+			//add the following two suggestions only, if player has the permissions
 			if(arg0.hasPermission("taggame.reset")) {
 				hints.add("reset");
 			}
+			
 			if(arg0.hasPermission("taggame.forceset")) {
 				hints.add("forceset");
 			}
+			
 		}
 		
+		
+		
+		
+		//If user is writing the second param of the command
 		else if(params.size() == 2) {
+			
+			//when first param was "get"
 			if(params.get(0).equalsIgnoreCase("get")) {
+				
 				hints.add("taboo");
-				hints.add("current");
+				hints.add("current"); //only used for completeness. Not used directly, but shows the player that there is more than one option
+			
 			}
 			
+			//if first param was "forceset"
 			else if(params.get(0).equalsIgnoreCase("forceset")) {
-				//show no hints, but instead the playerlist
+		
+				//show no hints, but instead the playerlist by returning null
 				return null;
+			
 			}
 			
 		}
 		
 		
+		
+		
+		//return the list of hints
         return hints;
         
 	}

--- a/src/de/Brogamer5000/tagGame/tagGame.java
+++ b/src/de/Brogamer5000/tagGame/tagGame.java
@@ -1,13 +1,17 @@
 package de.Brogamer5000.tagGame;
 
 import java.io.File;
+import java.util.logging.Logger;
+
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class tagGame extends JavaPlugin implements Listener{	
 	
-	String pluginPraefix = "§5[tagGame] §f";
-	CommandKit commandExecutor;
+	public static CommandKit commandExecutor;
+	public static tagGame instance;
+	public static Logger logger;
+	public static String prefix;
 	
 	//im Plugin genutzte Berechtigungen:
 	// taggame.reset 
@@ -22,27 +26,44 @@ public class tagGame extends JavaPlugin implements Listener{
 	@Override
 	public void onEnable() {
 
+		//create information for the logger
+		instance = this;
+		prefix = "§5[tagGame] §f";
+		logger = getLogger();
+		
+		//create folder for the stored Information
 		String pluginFolder = this.getDataFolder().getAbsolutePath();
-		(new File(pluginFolder)).mkdir();
+		new File(pluginFolder).mkdir();
 		
-		commandExecutor =  new CommandKit(pluginFolder, pluginPraefix);
 		
+		//save instance of the command-collection class
+		commandExecutor =  new CommandKit(pluginFolder, prefix);
+		
+		//add the 'taggame' command and set its executor and tabCompleter
 		this.getCommand("taggame").setExecutor(commandExecutor);
 		this.getCommand("taggame").setTabCompleter(new TabComplete());
 		
 		
-		//events
-		
+		//create the eventhandler
 		new CustomEventHandler(this);
+		
 		
 		this.getLogger().info("Taggame-Plugin successfully enabled");
 		
-		
 	}
+	
+	
+	
+	
 	
 	@Override
 	public void onDisable() {
+		
+		//save everything
+		commandExecutor.taggedPlayer.save();
+		
 		this.getLogger().info("Taggame-Plugin successfully disabled");
+	
 	}
 
 	


### PR DESCRIPTION
- Einzelne Verbesserungen am Code
- Es wird nun das Worldguard "DisallowPvpEvent" genutzt, anstatt des EntityHitByEntity-Events
- Anstatt die Tag-Liste und die Tabu-Liste bei jeder Veränderung direkt abzuspeichern, wird dies nun nur einmal beim Deaktivieren gemacht.
- Ist beim Laden des Plugins die Tag-Liste leer, wird ein Platzhalter eingefügt mit dem namen "dummyPlayer - please use /taggame reset"

Offene Probleme:
- Wenn ein Spieler einen anderen tagged, bekommt er trotzdem die Nachricht "Hey! Sorry, but you can´t pvp here!"
- Code bereinigung steht noch immer offen, weil ich sehr, sehr faul bin :P